### PR TITLE
Hjh

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import ChannelPage from "./pages/Channel/Channel";
 import HomePage from "./pages/Home/Home";
 import LoadingPage from "./pages/Loading/Loading";
 import TestPage from "./pages/Test/Test";
+import VideoPlayer from "./pages/VideoPlayer/VideoPlayer"
 //import FeedChannelsPage from "./pages/Feed/Channels";
 
 function App() {
@@ -23,6 +24,7 @@ function App() {
           /> */}
           <Route path={pageEndPoints.CHANNEL} element={<ChannelPage />} />
           <Route path={pageEndPoints.TEST} element={<TestPage />} />
+          <Route path={pageEndPoints.TEST} element={<VideoPlayer />} />
         </Routes>
       </Router>
     </AuthProvider>

--- a/src/apis/youtube.js
+++ b/src/apis/youtube.js
@@ -2,7 +2,7 @@ import { apiEndPoints } from "../constants/api";
 import youtubeAPI from "./youtubeInstance";
 
 const fetchVideos = async (maxResults = 10) => {
-  return await youtubeAPI.get(apiEndPoints.SEARCH, {
+  const response = await youtubeAPI.get(apiEndPoints.SEARCH, {
     params: {
       part: "snippet",
       chart: "mostPopular",
@@ -11,6 +11,24 @@ const fetchVideos = async (maxResults = 10) => {
       maxResults,
     },
   });
+
+  //채널 프로필 이미지를 불러오기 위해 channels api를 요청
+  const videos = response.data.items;
+  const channelIds = videos.map((video) => video.snippet.channelId);
+  const channelResponse = await fetchChannelDetails(channelIds.join(","));
+  const channels = channelResponse.data.items;
+
+  const result = videos.map((video) => {
+    const channelInfo = channels.find(
+      (channel) => channel.id === video.snippet.channelId
+    );
+    return {
+      ...video
+      ,channelInfo: channelInfo ? channelInfo.snippet : null,
+    }
+  });
+
+  return { data: result };
 };
 
 const fetchPlayLists = async (maxResults = 10) => {

--- a/src/layouts/DefaultLayout/Sidebar/Menu/Menu.jsx
+++ b/src/layouts/DefaultLayout/Sidebar/Menu/Menu.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import styles from "./Menu.module.css";
-import menuItems from "./constants/menuConstants"
+import menuItems from "./constants.js"
 
 
 const Menu = ({menu}) => {

--- a/src/pages/Home/Videos/Videos.jsx
+++ b/src/pages/Home/Videos/Videos.jsx
@@ -14,17 +14,24 @@ function Videos() {
 
 
   useEffect(() => {
-    //데이터 로드
+    //동영상+해당 동영상의 채널 정보를 함께 불러옴
     const fetchVideos = async () => {
       setIsLoading(true);
       try {
         const response = await YoutubeService.fetchVideos(page);
+        console.log(response);
         setVideos((prevVideos) =>
-          [...prevVideos, ...response.data.items].filter(
+          //중복된 동영상 제거
+          [...prevVideos, ...response.data].filter(
             (video, index, self) =>
               index === self.findIndex((v) => v.id.videoId === video.id.videoId)
           )
         );
+
+        console.log(videos);
+        console.log(videos[0].channelInfo.thumbnails.medium.url);
+        
+
       } catch (error) {
         console.error("Error fetching videos:", error);
       } finally {
@@ -32,7 +39,7 @@ function Videos() {
       }
     };
     fetchVideos();
-    console.log(videos);
+
   }, [page]);
 
   //옵저버
@@ -100,7 +107,7 @@ function Videos() {
             <div className={styles.video_information}>
               <img
                 className={styles.video_channel_img}
-                src="https://yt3.ggpht.com/yti/ANjgQV9PAjI-WMfy-zSByztHi-Gw0cX2ORxDdilHqSZCmhaR8w=s108-c-k-c0x00ffffff-no-rj"
+                src={video.channelInfo.thumbnails.medium.url}
                 onClick={()=> channelOnClick(video.snippet.channelId)}
               />
               <div>

--- a/src/pages/Home/Videos/Videos.jsx
+++ b/src/pages/Home/Videos/Videos.jsx
@@ -2,12 +2,16 @@ import { useEffect, useState, useRef } from "react";
 import YoutubeService from "../../../apis/youtube";
 import {formatISO} from "../../../utils/date.js"
 import styles from "./Videos.module.css";
+import { useNavigate } from "react-router-dom";
+
 
 function Videos() {
   const [videos, setVideos] = useState([]); // 비디오 데이터
   const [page, setPage] = useState(1); // 현재 페이지
   const [isLoading, setIsLoading] = useState(false); // 로딩 상태
   const observerTarget = useRef(null); // 관찰 대상
+  const navigate = useNavigate();
+
 
   useEffect(() => {
     //데이터 로드
@@ -52,10 +56,19 @@ function Videos() {
     };
   }, [isLoading]);
 
-  //비디오 클릭시 해당 비디오로 이동
-  const videoOnClick = (videoId) => {
-    const videoUrl = `https://www.youtube.com/watch?v=${videoId}`;
-    window.location.href = videoUrl;
+  // 비디오 클릭시 해당 비디오로 이동
+  // 주석 부분은 실제 유튜브 링크로 이동하는 메서드입니다
+  // const videoOnClick = (videoId) => {
+  //   const link = `./pages/VideoPlayer/VideoPlayer`;
+  //   window.location.href = videoUrl;
+  // }
+  const videoOnClick = (videoId)=>{
+    const videoUrl = `/pages/VideoPlayer/VideoPlayer/watch?v==${videoId}`;
+    if (videoUrl.startsWith("http")) {
+      window.open(videoUrl, "_blank");
+    } else {
+      navigate(videoUrl);
+    }
   }
 
   return (

--- a/src/pages/Home/Videos/Videos.jsx
+++ b/src/pages/Home/Videos/Videos.jsx
@@ -70,7 +70,7 @@ function Videos() {
   //   window.location.href = videoUrl;
   // }
   const videoOnClick = (videoId)=>{
-    const videoUrl = `/pages/VideoPlayer/VideoPlayer/watch?v==${videoId}`;
+    const videoUrl = `/pages/VideoPlayer/VideoPlayer/watch?v=${videoId}`;
     if (videoUrl.startsWith("http")) {
       window.open(videoUrl, "_blank");
     } else {
@@ -81,11 +81,11 @@ function Videos() {
   // 채널 썸네일 클릭시 해당 채널로 이동
   // 주석 부분은 실제 유튜브 링크로 이동하는 메서드입니다
   // const channelOnClick = (channelId) => {
-  //   const channelUrl = `/pages/Channel/Channel/${channelId}`;
+  //   const channelUrl = `https://www.youtube.com/channel/${channelId}`;
   //   window.location.href = channelUrl;
   // }
   const channelOnClick = (channelId)=>{
-    const channelUrl = `/pages/Channel/Channel${channelId}`;
+    const channelUrl = `/pages/Channel/Channel/${channelId}`;
     if (channelUrl.startsWith("http")) {
       window.open(channelUrl, "_blank");
     } else {

--- a/src/pages/Home/Videos/Videos.jsx
+++ b/src/pages/Home/Videos/Videos.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useRef } from "react";
 import YoutubeService from "../../../apis/youtube";
+import {formatISO} from "../../../utils/date.js"
 import styles from "./Videos.module.css";
 
 function Videos() {
@@ -9,6 +10,7 @@ function Videos() {
   const observerTarget = useRef(null); // 관찰 대상
 
   useEffect(() => {
+    //데이터 로드
     const fetchVideos = async () => {
       setIsLoading(true);
       try {
@@ -26,17 +28,17 @@ function Videos() {
       }
     };
     fetchVideos();
+    console.log(videos);
   }, [page]);
 
-  //옵저버 설정
+  //옵저버
   useEffect(() => {
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries[0].isIntersecting && !isLoading) {
-          setPage((prevPage) => prevPage + 1); // 페이지 증가
-        }
-      },
-      { threshold: 0.5 } // 대상이 100% 보일 때 실행
+          setPage((prevPage) => prevPage + 1); 
+      }},
+      { threshold: 0.5 }
     );
 
     if (observerTarget.current) {
@@ -50,6 +52,12 @@ function Videos() {
     };
   }, [isLoading]);
 
+  //비디오 클릭시 해당 비디오로 이동
+  const videoOnClick = (videoId) => {
+    const videoUrl = `https://www.youtube.com/watch?v=${videoId}`;
+    window.location.href = videoUrl;
+  }
+
   return (
     <div>
       <ul className={styles.video_list}>
@@ -59,12 +67,22 @@ function Videos() {
               className={styles.video_thumbnail}
               src={video.snippet.thumbnails.medium.url}
               alt={video.snippet.title}
+              onClick={()=> videoOnClick(video.id.videoId)}
             />
-            <div className={styles.video_description}>
+            <div className={styles.video_information}>
+              <img
+                className={styles.video_channel_img}
+                src="https://yt3.ggpht.com/yti/ANjgQV9PAjI-WMfy-zSByztHi-Gw0cX2ORxDdilHqSZCmhaR8w=s108-c-k-c0x00ffffff-no-rj"
+              />
+              <div>
               <p className={styles.video_title}>{video.snippet.title}</p>
-              <p className={styles.video_channeltitle}>
-                {video.snippet.channelTitle}
-              </p>
+              <p className={styles.video_channeltitle}>{video.snippet.channelTitle}</p>
+                <div className={styles.video_statistics}>
+                  <p className={styles.video_view_count}></p>
+                  <p className={styles.video_published_time}>{formatISO(video.snippet.publishTime)}</p>
+                </div>
+              </div>
+
             </div>
           </li>
         ))}

--- a/src/pages/Home/Videos/Videos.jsx
+++ b/src/pages/Home/Videos/Videos.jsx
@@ -13,7 +13,12 @@ function Videos() {
       setIsLoading(true);
       try {
         const response = await YoutubeService.fetchVideos(page);
-        setVideos((prevVideos) => [...prevVideos, ...response.data.items]);
+        setVideos((prevVideos) =>
+          [...prevVideos, ...response.data.items].filter(
+            (video, index, self) =>
+              index === self.findIndex((v) => v.id.videoId === video.id.videoId)
+          )
+        );
       } catch (error) {
         console.error("Error fetching videos:", error);
       } finally {

--- a/src/pages/Home/Videos/Videos.jsx
+++ b/src/pages/Home/Videos/Videos.jsx
@@ -1,31 +1,49 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import YoutubeService from "../../../apis/youtube";
 import styles from "./Videos.module.css";
 
 function Videos() {
-  const [videos, setVideos] = useState([]);
+  const [videos, setVideos] = useState([]); // 비디오 데이터
+  const [page, setPage] = useState(1); // 현재 페이지
+  const [isLoading, setIsLoading] = useState(false); // 로딩 상태
+  const observerTarget = useRef(null); // 관찰 대상
 
   useEffect(() => {
     const fetchVideos = async () => {
+      setIsLoading(true);
       try {
-        // const response = await api.get('/search', {
-        //     params: {
-        //       part: "snippet",
-        //       chart: "mostPopular",
-        //       type: "video",
-        //       regionCode:"KR",
-        //       maxResults: 10,
-        //     },
-        //   });
-        const response = await YoutubeService.fetchVideos();
-        setVideos(response.data.items);
+        const response = await YoutubeService.fetchVideos(page);
+        setVideos((prevVideos) => [...prevVideos, ...response.data.items]);
       } catch (error) {
         console.error("Error fetching videos:", error);
+      } finally {
+        setIsLoading(false);
       }
     };
-
     fetchVideos();
-  }, []);
+  }, [page]);
+
+  //옵저버 설정
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && !isLoading) {
+          setPage((prevPage) => prevPage + 1); // 페이지 증가
+        }
+      },
+      { threshold: 0.5 } // 대상이 100% 보일 때 실행
+    );
+
+    if (observerTarget.current) {
+      observer.observe(observerTarget.current);
+    }
+
+    return () => {
+      if (observerTarget.current) {
+        observer.unobserve(observerTarget.current);
+      }
+    };
+  }, [isLoading]);
 
   return (
     <div>
@@ -46,6 +64,7 @@ function Videos() {
           </li>
         ))}
       </ul>
+      <div ref={observerTarget} className={styles.loading}></div>
     </div>
   );
 }

--- a/src/pages/Home/Videos/Videos.jsx
+++ b/src/pages/Home/Videos/Videos.jsx
@@ -59,7 +59,7 @@ function Videos() {
   // 비디오 클릭시 해당 비디오로 이동
   // 주석 부분은 실제 유튜브 링크로 이동하는 메서드입니다
   // const videoOnClick = (videoId) => {
-  //   const link = `./pages/VideoPlayer/VideoPlayer`;
+  //   const videoUrl = `https://www.youtube.com/watch?v=${videoId}`;
   //   window.location.href = videoUrl;
   // }
   const videoOnClick = (videoId)=>{
@@ -68,6 +68,21 @@ function Videos() {
       window.open(videoUrl, "_blank");
     } else {
       navigate(videoUrl);
+    }
+  }
+
+  // 채널 썸네일 클릭시 해당 채널로 이동
+  // 주석 부분은 실제 유튜브 링크로 이동하는 메서드입니다
+  // const channelOnClick = (channelId) => {
+  //   const channelUrl = `/pages/Channel/Channel/${channelId}`;
+  //   window.location.href = channelUrl;
+  // }
+  const channelOnClick = (channelId)=>{
+    const channelUrl = `/pages/Channel/Channel${channelId}`;
+    if (channelUrl.startsWith("http")) {
+      window.open(channelUrl, "_blank");
+    } else {
+      navigate(channelUrl);
     }
   }
 
@@ -81,11 +96,12 @@ function Videos() {
               src={video.snippet.thumbnails.medium.url}
               alt={video.snippet.title}
               onClick={()=> videoOnClick(video.id.videoId)}
-            />
+              />
             <div className={styles.video_information}>
               <img
                 className={styles.video_channel_img}
                 src="https://yt3.ggpht.com/yti/ANjgQV9PAjI-WMfy-zSByztHi-Gw0cX2ORxDdilHqSZCmhaR8w=s108-c-k-c0x00ffffff-no-rj"
+                onClick={()=> channelOnClick(video.snippet.channelId)}
               />
               <div>
               <p className={styles.video_title}>{video.snippet.title}</p>

--- a/src/pages/Home/Videos/Videos.module.css
+++ b/src/pages/Home/Videos/Videos.module.css
@@ -57,3 +57,8 @@
   font-size: small;
   color: gray;
 }
+
+.loading {
+  height: 20px;
+  margin: 20px auto;
+}

--- a/src/pages/Home/Videos/Videos.module.css
+++ b/src/pages/Home/Videos/Videos.module.css
@@ -39,12 +39,23 @@
   border-radius: 10px;
 }
 
+.video_information{
+  display: flex;
+}
+
+.video_channel_img{
+  width: 15%;
+  height: 100%;
+  margin: 5px;
+  border-radius: 50%;
+}
+
 .video_title {
   width: 100%;
   margin: 5px 0px;
   font-weight: bold;
   font-size: medium;
-
+  
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -52,10 +63,16 @@
   text-overflow: ellipsis;
 }
 
-.video_channeltitle {
+.video_channeltitle, 
+.video_view_count, 
+.video_published_time{
   margin: 0px 0px 20px 0px;
   font-size: small;
   color: gray;
+}
+
+.video_statistics{
+  display: flex;
 }
 
 .loading {

--- a/src/pages/Home/Videos/Videos.module.css
+++ b/src/pages/Home/Videos/Videos.module.css
@@ -46,7 +46,7 @@
   font-size: medium;
 
   display: -webkit-box;
-  line-clamp: 2;
+  -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## #️⃣연관된 이슈

> SCRUM 19, 20, 22, 23
## 📝작업 내용
> 메인페이지의 동영상 목록 구현: 각 동영상마다 조회수를 제외한 나머지 구역 구현 완료
> 채널 프로필 이미지를 클릭할 때 해당 채널 페이지로 이동하는 기능 구현
> 동영상 썸네일을 클릭할 때 해당 동영상 페이지로 이동하는 기능 구현
> 옵저버를 이용한 동영상 목록 무한 스크롤 기능 구현
> 시연 동영상 첨부: https://github.com/user-attachments/assets/a22ac3b4-78fd-4f58-93ff-a9b60cc1431b




## 💬코드리뷰 요구사항(선택)
> search api로 동영상을 불러오면 채널 프로필 이미지 url은 불러와지지 않아서 api/youtube.js의 fetchVideos 메서드를 수정했고, 그 결과 반환되는 객체 모양이 달라졌습니다 (기존 객체에 `channelInfo` 추가) 저만 쓰던 메서드같긴 하지만 혹시 몰라서 적어봅니다!
