### PR TITLE
Fix: 스크롤해도 사이드바 버튼이 움직이지 않도록 수정

### DIFF
--- a/src/layouts/DefaultLayout/DefaultLayout.module.css
+++ b/src/layouts/DefaultLayout/DefaultLayout.module.css
@@ -45,7 +45,7 @@
   background-color: #ffffff;
 
   /*스크롤에 관계없이 위치 고정*/
-  position: absolute fixed; 
+  position: fixed; 
   top: 0px;
   left: 0px;
   z-index: 100;


### PR DESCRIPTION
## 📝작업 내용

> 메인페이지에서 헤더와 사이드바가 스크롤에 관계없이 고정되도록 했는데, 나중에 추가했던 사이드바 버튼만 설정을 안해둬서 스크롤하면 사이드바 버튼이 같이 올라가 사라지는 현상을 수정했습니다!

## 💬코드리뷰 요구사항(선택)

